### PR TITLE
Update match_motif.py

### DIFF
--- a/pychromvar/match_motif.py
+++ b/pychromvar/match_motif.py
@@ -1,5 +1,9 @@
 import os
-from typing import Union, Literal, get_args
+from typing import Union
+try:
+    from typing import Literal, get_args # for python 3.8 and above
+except ImportError:
+    from typing_extensions import Literal, get_args # for python lower than 3.8
 import numpy as np
 from tqdm import tqdm
 import MOODS.scan


### PR DESCRIPTION
importing Literal and get_args is not compatible with python lower than 3.8. By adding the try/except makes the module compatible with python 3.7.*