### PR TITLE
multiprocessing and faster matrix operations

### DIFF
--- a/pychromvar/__init__.py
+++ b/pychromvar/__init__.py
@@ -3,6 +3,6 @@ __version_info__ = tuple([int(num) for num in __version__.split('.')])  # noqa: 
 
 from .preprocessing import get_bg_peaks, add_gc_bias, add_peak_seq
 from .match_motif import match_motif
-from .compute_deviations import compute_deviations, compute_expectation
+from .compute_deviations import compute_deviations
 from .get_genome import get_genome
 

--- a/pychromvar/compute_deviations.py
+++ b/pychromvar/compute_deviations.py
@@ -1,20 +1,55 @@
-from typing import Union
 from anndata import AnnData
 from mudata import MuData
+from typing import Union
 import numpy as np
-from scipy import sparse
-from multiprocessing import Pool, cpu_count
-import logging
+from scipy.sparse import csr_matrix
 from tqdm.auto import tqdm
+from multiprocessing import Pool, cpu_count, shared_memory
+import logging
 
-logging.basicConfig(
-    format='%(asctime)s %(levelname)-8s %(message)s',
-    level=logging.INFO,
-    datefmt='%Y-%m-%d %H:%M:%S')
+def process_background_set(args):
+    """Compute Y' for one of the background sets of peaks"""
+    i, shm_name, X_shape, fraction, per_cell_sum, bg_peaks, M_shape, M_data, M_indices, M_indptr = args
 
+    # Load shared memory for X
+    shm = shared_memory.SharedMemory(name=shm_name)
+    X = np.ndarray(X_shape, dtype=np.float32, buffer=shm.buf)
 
-def compute_deviations(data: Union[AnnData, MuData], n_jobs=-1, chunk_size:int=10000) -> AnnData:
-    """Compute raw and bias-corrected deviations.
+    # Reconstruct sparse matrix M
+    M = csr_matrix((M_data, M_indices, M_indptr), shape=M_shape)
+
+    # Replace peaks for this background set
+    replacement_idx = bg_peaks[:, i]
+    rows, cols = M.nonzero()
+    new_rows = replacement_idx[rows]
+    M_r = csr_matrix((M.data, (new_rows, cols)), shape=M.shape)
+
+    # Compute (MxB)xE' 
+    obs_fragments = X @ M_r
+    tf_fraction = M_r.multiply(fraction[:, np.newaxis]).sum(axis=0).A1
+    e_fragments = (per_cell_sum[:, np.newaxis] * tf_fraction)
+    
+    # Compute MxE' 
+    tf_fraction_ = M.multiply(fraction[:, np.newaxis]).sum(axis=0).A1
+    e_fragments_ = (per_cell_sum[:, np.newaxis] * tf_fraction_)
+    
+    # Conmpute Y'
+    Y_r = (obs_fragments - e_fragments) / e_fragments_
+
+    return Y_r
+
+def compute_Y(X, M, fraction, n_fragments):
+    """Compute Y matrix"""
+    obs_fragments = X @ M
+    tf_fraction = M.multiply(fraction[:, np.newaxis]).sum(axis=0).A1
+    e_fragments = (n_fragments[:, np.newaxis] * tf_fraction)
+    Y = (obs_fragments - e_fragments) / e_fragments
+
+    return Y
+
+def compute_deviations(data: Union[AnnData, MuData], n_jobs=-1) -> AnnData:
+
+    """Compute bias-corrected deviations.
 
     Parameters
     ----------
@@ -22,81 +57,101 @@ def compute_deviations(data: Union[AnnData, MuData], n_jobs=-1, chunk_size:int=1
         AnnData object with peak counts or MuData object with 'atac' modality.
     n_jobs : int, optional
         Number of cpus used for motif matching. If set to -1, all cpus will be used. Default: -1.
-
+        
     Returns
     -------
     Anndata
         An anndata object containing estimated deviations.
     """
+
     if isinstance(data, AnnData):
         adata = data
     elif isinstance(data, MuData) and "atac" in data.mod:
         adata = data.mod["atac"]
     else:
-        raise TypeError(
-            "Expected AnnData or MuData object with 'atac' modality")
-    # check if the object contains bias in Anndata.varm
-    assert "bg_peaks" in adata.varm_keys(
-    ), "Cannot find background peaks in the input object, please first run get_bg_peaks!"
-    logging.info('computing expectation reads per cell and peak...')
-    expectation_obs, expectation_var = compute_expectation(count=adata.X)
-    logging.info('computing observed + bg motif deviations...')
-    motif_match = adata.varm['motif_match']
-    obs_dev = np.zeros((adata.n_obs, motif_match.shape[1]), dtype=np.float32)
-    # compute background deviations for bias-correction
-    n_bg_peaks = adata.varm['bg_peaks'].shape[1]
-    bg_dev = np.zeros(shape=(n_bg_peaks, adata.n_obs, len(
-        adata.uns['motif_name'])), dtype=np.float32)
-    ### instead of iterating over bg peaks, iterate over X
-    for item in tqdm(adata.chunked_X(chunk_size), position=0, leave=False, ncols=80, desc="rows"):
-        X, start, end = item
-        obs_dev[start:end, :] = _compute_deviations((motif_match, X, expectation_obs[start:end], expectation_var))
-        for i in tqdm(range(n_bg_peaks), position=1, leave=False, ncols=80, desc="bg"):
-            bg_peak_idx = adata.varm['bg_peaks'][:, i]
-            bg_motif_match = adata.varm['motif_match'][bg_peak_idx, :]
-            bg_dev[i, start:end, :] = _compute_deviations((bg_motif_match, X, expectation_obs[start:end], expectation_var))
-    mean_bg_dev = np.mean(bg_dev, axis=0)
-    std_bg_dev = np.std(bg_dev, axis=0)
-    dev = (obs_dev - mean_bg_dev) / std_bg_dev
+        raise TypeError("Expected AnnData or MuData object with 'atac' modality")
+    
+    assert "bg_peaks" in adata.varm_keys(), "Cannot find background peaks in the input object."
+    assert "motif_match" in adata.varm_keys(), "Cannot find motif_match in the input object."
+
+    # X should be dense and M should be csr
+    if not isinstance(adata.X, csr_matrix):
+        X = adata.X
+    else:
+        X = adata.X.toarray()
+
+    if not isinstance(adata.varm['motif_match'], csr_matrix):
+        M = csr_matrix(adata.varm['motif_match'])
+    else:
+        M = adata.varm['motif_match']
+
+    bg_peaks = adata.varm['bg_peaks']
+    N_bkg_sets = bg_peaks.shape[1]
+
+    # Make the vectors to reconstruct E 
+    per_peak_sum = np.array(X.sum(axis=0)).flatten()
+    total = np.sum(per_peak_sum)
+    fraction = per_peak_sum / total
+
+    per_cell_sum = np.array(X.sum(axis=1)).flatten()
+
+    logging.info('computing raw deviations...')
+
+    # Copy X to shared memory
+    shm_X = shared_memory.SharedMemory(create=True, size=X.nbytes)
+    shared_array = np.ndarray(X.shape, dtype=X.dtype, buffer=shm_X.buf)
+    np.copyto(shared_array, X)  
+
+    # Compute Y
+    Y = compute_Y(X, M, fraction, per_cell_sum)
+
+    logging.info('launching parallel jobs to compute background devs...')
+    n_jobs = cpu_count() if n_jobs == -1 else n_jobs
+
+    # Prepare arguments for multiprocessing
+    args = [
+        (
+            i,
+            shm_X.name,
+            X.shape,
+            fraction,
+            per_cell_sum,
+            bg_peaks,
+            M.shape,
+            M.data,
+            M.indices,
+            M.indptr,
+        )
+        for i in range(N_bkg_sets)
+    ]
+
+    # Parallel computation
+    with Pool(n_jobs) as pool:
+        results = list(
+            tqdm(
+                pool.imap(process_background_set, args),
+                total=N_bkg_sets,
+                desc="processing background peak sets",
+            )
+        )
+
+    # Compute mean and standard deviation
+    logging.info('computing mean and std dev of background devs...')
+    mean_Y = np.mean(results, axis=0)
+    std_Y = np.std(results, axis=0)
+
+    # Cleanup shared memory
+    shm_X.close()
+    shm_X.unlink()
+
+    # Compute bias-corrected deviations
+    logging.info('calculate bias corrected deviations...')
+    dev = (Y - mean_Y) / std_Y
     dev = np.nan_to_num(dev, 0)
-    dev = AnnData(dev, dtype=np.float32)
+
+    # Create AnnData
+    dev = AnnData(dev)
     dev.obs_names = adata.obs_names
     dev.var_names = adata.uns['motif_name']
+
     return dev
-
-
-def _compute_deviations(arguments):
-    motif_match, count, expectation_obs, expectation_var = arguments
-    ### motif_match: n_var x n_motif
-    ### count, exp: n_obs x n_var
-    observed = count.dot(motif_match)
-    expected = expectation_obs.dot(expectation_var.dot(motif_match))
-    if sparse.issparse(observed):
-        observed = observed.todense()
-    if sparse.issparse(expected):
-        expected = expected.todense()
-    out = np.zeros(expected.shape, dtype=expected.dtype)
-    np.divide(observed - expected, expected, out=out, where=expected != 0)
-    return out
-
-
-def compute_expectation(count: Union[np.array, sparse.csr_matrix]) -> np.array:
-    """
-    Compute expetation accessibility per peak and per cell by assuming
-    identical read probability per peak for each cell with a sequencing
-    depth matched to that cell observed sequencing depth
-
-    Parameters
-    ----------
-    count : Union[np.array, sparse.csr_matrix]
-        Count matrix containing raw accessibility data.
-
-    Returns
-    -------
-    np.array, np.array
-        Expectation matrix pair when multiplied gives
-    """
-    a = np.asarray(count.sum(0), dtype=np.float32).reshape((1, count.shape[1]))
-    a /= a.sum()
-    b = np.asarray(count.sum(1), dtype=np.float32).reshape((count.shape[0], 1))
-    return b, a


### PR DESCRIPTION
Re-implemented the compute_deviations function with multiprocessing with X (fragment counts) in shared memory. Also changed some of the matrix operations. 

I looked at the original chromVAR paper so math might be slightly different. 

Correlation with original implementation seems good (~0.99 on example data). I time with n_jobs=1 it is 2-3X faster and with n_jobs=5 it is 9X faster. 

(this version doesn't use compute_expectation which fails existing test)